### PR TITLE
Add python3 kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,15 +137,9 @@ RUN cd /tmp && \
     rm Miniconda3-4.2.12-Linux-x86_64.sh && \
     $CONDA3_DIR/bin/conda config --system --add channels conda-forge && \
     $CONDA3_DIR/bin/conda config --system --set auto_update_conda false && \
+    $CONDA3_DIR/bin/conda install --quiet --yes \
+    notebook matplotlib pandas pip && \
     $CONDA3_DIR/bin/conda clean -tipsy
-
-RUN $CONDA3_DIR/bin/conda install --quiet --yes \
-    notebook matplotlib pandas pip \
-    && $CONDA3_DIR/bin/conda clean -tipsy
-
-USER $NB_USER
-RUN $CONDA3_DIR/bin/ipython kernel install --user
-USER root
 
 ### extensions for jupyter (python2)
 
@@ -193,21 +187,15 @@ RUN jupyter kernelspec install /tmp/kernels/python2-wrapper --user
 ### extensions for Jupyter (python3)
 USER root
 RUN $CONDA3_DIR/bin/pip install \
-    https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master
-USER $NB_USER
-RUN $CONDA3_DIR/bin/jupyter kernelspec install /tmp/kernels/python3-wrapper --user
-USER root
+    https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master && \
+    $CONDA3_DIR/bin/pip install jupyter_nbextensions_configurator ipywidgets && \
+    $CONDA3_DIR/bin/pip install https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/tarball/master
 
-#### jupyter_nbextensions_configurator
-RUN $CONDA3_DIR/bin/pip install jupyter_nbextensions_configurator ipywidgets
-    
-#### Jupyter-LC_nblineage (NII) - https://github.com/NII-cloud-operation/Jupyter-LC_nblineage
-RUN $CONDA3_DIR/bin/pip install https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/tarball/master
 USER $NB_USER
-RUN $CONDA3_DIR/bin/jupyter nblineage quick-setup --user
-
-#### widgetsnbextension
-RUN $CONDA3_DIR/bin/jupyter nbextension enable --user --py widgetsnbextension
+RUN $CONDA3_DIR/bin/ipython kernel install --user && \
+    $CONDA3_DIR/bin/jupyter kernelspec install /tmp/kernels/python3-wrapper --user && \
+    $CONDA3_DIR/bin/jupyter nblineage quick-setup --user && \
+    $CONDA3_DIR/bin/jupyter nbextension enable --user --py widgetsnbextension
 
 ### notebooks dir
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,27 @@ RUN pip install pysnmp pysnmp-mibs
 ### Add files
 RUN mkdir -p /etc/ansible && cp /tmp/ansible.cfg /etc/ansible/ansible.cfg
 
-### extensions for jupyter
+### environments for Python3
+ENV CONDA3_DIR /opt/conda3
+RUN cd /tmp && \
+    mkdir -p $CONDA3_DIR && \
+    wget --quiet https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh && \
+    echo "c59b3dd3cad550ac7596e0d599b91e75d88826db132e4146030ef471bb434e9a *Miniconda3-4.2.12-Linux-x86_64.sh" | sha256sum -c - && \
+    /bin/bash Miniconda3-4.2.12-Linux-x86_64.sh -f -b -p $CONDA3_DIR && \
+    rm Miniconda3-4.2.12-Linux-x86_64.sh && \
+    $CONDA3_DIR/bin/conda config --system --add channels conda-forge && \
+    $CONDA3_DIR/bin/conda config --system --set auto_update_conda false && \
+    $CONDA3_DIR/bin/conda clean -tipsy
+
+RUN $CONDA3_DIR/bin/conda install --quiet --yes \
+    notebook matplotlib pandas pip \
+    && $CONDA3_DIR/bin/conda clean -tipsy
+
+USER $NB_USER
+RUN $CONDA3_DIR/bin/ipython kernel install --user
+USER root
+
+### extensions for jupyter (python2)
 
 #### jupyter_nbextensions_configurator
 RUN pip install jupyter_nbextensions_configurator
@@ -169,6 +189,25 @@ USER root
 RUN pip install https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master
 USER $NB_USER
 RUN jupyter kernelspec install /tmp/kernels/python2-wrapper --user
+
+### extensions for Jupyter (python3)
+USER root
+RUN $CONDA3_DIR/bin/pip install \
+    https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master
+USER $NB_USER
+RUN $CONDA3_DIR/bin/jupyter kernelspec install /tmp/kernels/python3-wrapper --user
+USER root
+
+#### jupyter_nbextensions_configurator
+RUN $CONDA3_DIR/bin/pip install jupyter_nbextensions_configurator ipywidgets
+    
+#### Jupyter-LC_nblineage (NII) - https://github.com/NII-cloud-operation/Jupyter-LC_nblineage
+RUN $CONDA3_DIR/bin/pip install https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/tarball/master
+USER $NB_USER
+RUN $CONDA3_DIR/bin/jupyter nblineage quick-setup --user
+
+#### widgetsnbextension
+RUN $CONDA3_DIR/bin/jupyter nbextension enable --user --py widgetsnbextension
 
 ### notebooks dir
 USER root

--- a/conf/kernels/python3-wrapper/kernel.json
+++ b/conf/kernels/python3-wrapper/kernel.json
@@ -1,0 +1,11 @@
+{
+ "display_name": "Python 3 (LC_wrapper)",
+ "language": "python",
+ "argv": [
+  "/opt/conda3/bin/python",
+  "-m",
+  "lc_wrapper",
+  "-f",
+  "{connection_file}"
+ ]
+}


### PR DESCRIPTION
Add python3 kernel to the image.

Python3 environment is installed using Miniconda3 (on `/opt/conda3/`). Also these libraries are installed:

- IPython kernel with LC_wrapper
- matplotlib
- pandas
- pip