### PR TITLE
Disable delete_to_trash to prevent an error while deleting

### DIFF
--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -2,9 +2,9 @@ import os
 c.NotebookApp.ip = '*'
 c.MultiKernelManager.kernel_manager_class = 'lc_wrapper.LCWrapperKernelManager'
 c.KernelManager.shutdown_wait_time = 10.0
+c.FileContentsManager.delete_to_trash = False
 
 if 'PASSWORD' in os.environ:
     from notebook.auth import passwd
     c.NotebookApp.password = passwd(os.environ['PASSWORD'])
     del os.environ['PASSWORD']
-


### PR DESCRIPTION
Disable delete_to_trash to prevent an error while deleting