### PR TITLE
Remove i18n extension because it has been obsolete

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,6 @@ RUN $CONDA3_DIR/bin/pip --no-cache-dir install folium
 ### extensions for jupyter (python2)
 #### jupyter_nbextensions_configurator
 #### jupyter_contrib_nbextensions
-#### nbextension_i18n (NII) - https://github.com/NII-cloud-operation/Jupyter-i18n_cells
 #### Jupyter-LC_nblineage (NII) - https://github.com/NII-cloud-operation/Jupyter-LC_nblineage
 #### Jupyter-LC_through (NII) - https://github.com/NII-cloud-operation/Jupyter-LC_run_through
 #### Jupyter-LC_wrapper (NII) - https://github.com/NII-cloud-operation/Jupyter-LC_wrapper
@@ -126,7 +125,6 @@ RUN $CONDA3_DIR/bin/pip --no-cache-dir install folium
 RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
     pip --no-cache-dir install six \
     https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tarball/master \
-    git+https://github.com/NII-cloud-operation/Jupyter-i18n_cells.git \
     https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/tarball/master \
     https://github.com/NII-cloud-operation/Jupyter-LC_run_through/tarball/master \
     https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master \
@@ -138,8 +136,6 @@ RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
 USER $NB_USER
 RUN mkdir -p $HOME/.local/share && \
     jupyter contrib nbextension install --user && \
-    jupyter nbextension install --py nbextension_i18n_cells --user && \
-    jupyter nbextension enable --py nbextension_i18n_cells --user && \
     jupyter nblineage quick-setup --user && \
     jupyter run-through quick-setup --user && \
     jupyter nbextension install --py lc_multi_outputs --user && \

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The goals for Literate Computing tools are:
     - multi_outputs https://github.com/NII-cloud-operation/Jupyter-multi_outputs
     - run_through https://github.com/NII-cloud-operation/Jupyter-LC_run_through
     - nblineage https://github.com/NII-cloud-operation/Jupyter-LC_nblineage
-    - i18n_cells https://github.com/NII-cloud-operation/Jupyter-i18n_cells
     - index https://github.com/NII-cloud-operation/Jupyter-LC_index
 
 ## Basic Use

--- a/conf/notebook.json
+++ b/conf/notebook.json
@@ -8,7 +8,6 @@
     "collapsible_headings/main": true,
     "nblineage/main": true,
     "run_through/main": true,
-    "nbextension_i18n_cells/main": true,
     "lc_wrapper/main": true
   },
   "toc_number_sections": true,


### PR DESCRIPTION
Remove i18n extension because it has been obsolete.

Fix #44 