### PR TITLE
Fix version of papermill to prevent package conflicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && \
 ### Utilities
 RUN apt-get update && apt-get install -y virtinst dnsutils zip tree jq rsync iputils-ping && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    pip --no-cache-dir install netaddr pyapi-gitlab runipy papermill \
+    pip --no-cache-dir install netaddr pyapi-gitlab runipy papermill==0.19.0 \
                 pysnmp pysnmp-mibs
 
 ### Add files


### PR DESCRIPTION
Fixing the version of papermill to 0.19.0 because the latest papermill (1.0.0) requires latest nbconvert (5.5) but jupyter/scipy-notebook has no latest one.