### PR TITLE
更新監視lsyncdの`NBSEARCH_BASE_DIR`環境変数対応

### DIFF
--- a/conf/nbsearch/update-index.lua
+++ b/conf/nbsearch/update-index.lua
@@ -12,4 +12,4 @@ settings {
   nodaemon   = false,
 }
 
-sync{update_index, source="/home/" .. os.getenv("NB_USER")}
+sync{update_index, source=os.getenv("NBSEARCHDB_BASE_DIR") or ("/home/" .. os.getenv("NB_USER"))}


### PR DESCRIPTION
更新監視lsyncdのパラメータに関して、環境変数 `NBSEARCH_BASE_DIR` への考慮が抜けていましたので修正しました。