### PR TITLE
Add NBWhisper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,8 @@ RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
     git+https://github.com/NII-cloud-operation/Jupyter-LC_index.git \
     git+https://github.com/NII-cloud-operation/Jupyter-LC_notebook_diff.git \
     git+https://github.com/NII-cloud-operation/sidestickies.git \
-    git+https://github.com/NII-cloud-operation/nbsearch.git
+    git+https://github.com/NII-cloud-operation/nbsearch.git \
+    git+https://github.com/NII-cloud-operation/nbwhisper.git
 
 
 RUN jupyter contrib nbextension install --sys-prefix && \
@@ -88,6 +89,8 @@ RUN jupyter contrib nbextension install --sys-prefix && \
     jupyter nbclassic-serverextension enable --py nbtags --sys-prefix && \
     jupyter nbclassic-extension install --py nbsearch --sys-prefix && \
     jupyter nbclassic-serverextension enable --py nbsearch --sys-prefix && \
+    jupyter nbclassic-extension install --py nbwhisper --sys-prefix && \
+    jupyter nbclassic-serverextension enable --py nbwhisper --sys-prefix && \
     jupyter nbclassic-extension install --py jupyter_nbextensions_configurator --sys-prefix && \
     jupyter nbclassic-extension enable --py jupyter_nbextensions_configurator --sys-prefix && \
     jupyter nbclassic-serverextension enable --py jupyter_nbextensions_configurator --sys-prefix && \

--- a/README.md
+++ b/README.md
@@ -89,3 +89,14 @@ You will be able to use NBSearch once you set up your Solr and S3 compatible sto
 - `-e NBSEARCHDB_MY_SERVER_URL=your_notebook_server_url` - URL of my server, used to identify the notebooks on this server(default: `http://localhost:8888/`)
 - `-e NBSEARCHDB_AUTO_UPDATE=1` - Launch lsyncd process to update the index of Solr when local files are updated automatically
 - `-e NBSEARCHDB_UPDATE_INDEX_OPT` - Options for the `update-index` NBSearch command invoked by the lsyncd process
+
+### Using NBWhisper
+
+You can use [NBWhisper](https://github.com/NII-cloud-operation/nbwhisper) by enabling the NBWhisper extension via the Nbextensions tab.
+
+To use NBWhisper, you need an API token of the SkyWay (WebRTC) service. It can be specified from environment variables as follows.
+(For more information, see https://github.com/NII-cloud-operation/nbwhisper/ .)
+
+- `-e NBWHISPER_SKYWAY_API_TOKEN` - An api token for SkyWay. This nbextension is not compatible with new SkyWay service, but old one. You can get an api token from your old SkyWay admin page. https://console-webrtc-free.ecl.ntt.com/users/login
+- `-e NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM` - Room mode for waiting room. Input "sfu" or "mesh" as waiting room mode you want to use.
+- `-e NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM` - Room mode for talking room. Input "sfu" or "mesh" as talking room mode you want to use.

--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -65,3 +65,14 @@ c.LocalSource.base_dir = os.environ['NBSEARCHDB_BASE_DIR'] \
 c.LocalSource.server = os.environ['NBSEARCHDB_MY_SERVER_URL'] \
                        if 'NBSEARCHDB_MY_SERVER_URL' in os.environ else \
                        'http://localhost:8888/'
+
+if 'NBWHISPER_SKYWAY_API_TOKEN' in os.environ:
+    c.NBWhisper.skyway_api_token = os.environ['NBWHISPER_SKYWAY_API_TOKEN']
+    # Secrets removed from environment variables
+    del os.environ['NBWHISPER_SKYWAY_API_TOKEN']
+
+if 'NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM' in os.environ:
+    c.NBWhisper.room_mode_for_waiting_room = os.environ['NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM']
+
+if 'NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM' in os.environ:
+    c.NBWhisper.room_mode_for_talking_room = os.environ['NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM']


### PR DESCRIPTION
Add NBWhisper https://github.com/NII-cloud-operation/nbwhisper - It is not enabled by default, similar to nbsearch. It becomes available when a token is given in an environment variable, etc., and the user enables the extension.