### PR TITLE
Fix initialize process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,12 @@ FROM niicloudoperation/notebook:base-demo
 USER root
 
 COPY conf/99-run-supervisor.sh /usr/local/bin/before-notebook.d/99-run-supervisor.sh
+COPY conf/supervisor-jovyan.conf /home/jovyan/.nbsearch/supervisor.conf
+COPY conf/supervisor-root.conf /home/jovyan/.nbsearch/supervisor-root.conf
+COPY conf/init-script.sh /home/jovyan/.nbsearch/init-script.sh
 ADD sample-notebooks /home/$NB_USER
 RUN chmod +x /usr/local/bin/before-notebook.d/99-run-supervisor.sh && \
+    chmod +x /home/jovyan/.nbsearch/init-script.sh && \
     fix-permissions /home/$NB_USER
 
 USER $NB_USER

--- a/conf/99-run-supervisor.sh
+++ b/conf/99-run-supervisor.sh
@@ -3,19 +3,9 @@
 set -xe
 
 # For Solr
-supervisord -c /home/jovyan/.nbsearch/supervisor.conf
-
-if [[ ! -f /home/$NB_USER/.nbsearch/config_local.py ]] ; then
-    while ! nc -z localhost 8983; do
-      sleep 0.5
-    done
-    while ! nc -z localhost 9000; do
-      sleep 0.5
-    done
-    while ! curl http://localhost:8983/solr/jupyter-cell/admin/ping | grep '"status":"OK"'; do
-      sleep 0.5
-    done
-    jupyter nbsearch update-index --debug /home/$NB_USER/.jupyter/jupyter_notebook_config.py local &
+if [ "$EUID" -eq 0 ]; then
+    cp -f /home/jovyan/.nbsearch/supervisor-root.conf /home/jovyan/.nbsearch/supervisor.conf
 fi
+supervisord -c /home/jovyan/.nbsearch/supervisor.conf
 
 export SUPERVISOR_INITIALIZED=1

--- a/conf/init-script.sh
+++ b/conf/init-script.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xe
+
+if [[ ! -f /home/$NB_USER/.nbsearch/config_local.py ]] ; then
+    while ! nc -z localhost 8983; do
+      sleep 0.5
+    done
+    while ! nc -z localhost 9000; do
+      sleep 0.5
+    done
+    while ! curl http://localhost:8983/solr/jupyter-cell/admin/ping | grep '"status":"OK"'; do
+      sleep 0.5
+    done
+    jupyter nbsearch update-index --debug /home/$NB_USER/.jupyter/jupyter_notebook_config.py local &
+fi

--- a/conf/supervisor-jovyan.conf
+++ b/conf/supervisor-jovyan.conf
@@ -1,0 +1,40 @@
+[supervisord]
+logfile = /tmp/supervisor-daemon.log
+pidfile = /tmp/supervisor.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[include]
+files = /home/jovyan/conf.d/*.conf
+
+[program:solr]
+command=/opt/docker-solr/scripts/solr-foreground
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+priority=10
+
+[program:minio]
+command=/opt/minio/bin/minio server /var/minio
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+priority=10
+
+[program:lsyncd]
+command=lsyncd -nodaemon /home/jovyan/.nbsearch/update-index.lua
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+priority=10
+
+[program:init]
+command=/home/jovyan/.nbsearch/init-script.sh
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=false
+priority=10

--- a/conf/supervisor-root.conf
+++ b/conf/supervisor-root.conf
@@ -1,0 +1,44 @@
+[supervisord]
+logfile = /tmp/supervisor-daemon.log
+pidfile = /tmp/supervisor.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[inet_http_server]
+port = 127.0.0.1:9001
+
+[include]
+files = /home/jovyan/conf.d/*.conf
+
+[program:solr]
+command=/opt/docker-solr/scripts/solr-foreground
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+user=%(ENV_NB_USER)s
+priority=10
+
+[program:minio]
+command=/opt/minio/bin/minio server /var/minio
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+user=%(ENV_NB_USER)s
+priority=10
+
+[program:lsyncd]
+command=lsyncd -nodaemon /home/jovyan/.nbsearch/update-index.lua
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=true
+user=%(ENV_NB_USER)s
+priority=10
+
+[program:init]
+command=/home/jovyan/.nbsearch/init-script.sh
+stdout_logfile=/tmp/supervisor-%(program_name)s.log
+stderr_logfile=//tmp/supervisor-%(program_name)s.log
+autorestart=false
+user=%(ENV_NB_USER)s
+priority=10


### PR DESCRIPTION
Modified the initialization script to ensure that MyBinder starts within the startup time limit (30 seconds or less).
Also, since `NB_USER` may not be `jovyan` in some environments, we modified the supervisor settings in a environment-aware manner.