### PR TITLE
Use lc_wrapper.AsyncLCWrapperKernelManager for kernel_manager_class

### DIFF
--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -1,7 +1,7 @@
 import os
 c.NotebookApp.ip = '*'
 c.NotebookApp.allow_remote_access = True
-c.MultiKernelManager.kernel_manager_class = 'lc_wrapper.LCWrapperKernelManager'
+c.MultiKernelManager.kernel_manager_class = 'lc_wrapper.AsyncLCWrapperKernelManager'
 c.KernelManager.shutdown_wait_time = 10.0
 c.FileContentsManager.delete_to_trash = False
 c.NotebookApp.quit_button = False


### PR DESCRIPTION
Use lc_wrapper.AsyncLCWrapperKernelManager for kernel_manager_class to fix the error https://github.com/jupyter/notebook/issues/6721