### PR TITLE
Add ep_weave support of sidestickies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@ You may customize the execution of Docker container and the Notebook server cont
 
 ### Using sidestickies
 
-You can use [sidestickies](https://github.com/NII-cloud-operation/sidestickies) by the following steps.
+You can use [sidestickies](https://github.com/NII-cloud-operation/sidestickies) by either of the following steps.
 
+Using Scrapbox https://scrapbox.io/:
 - Add `-e SIDESTICKIES_SCRAPBOX_PROJECT_ID=value -e SIDESTICKIES_SCRAPBOX_COOKIE_CONNECT_SID=value` to docker options - Specify Scrapbox account to [sidestickies](https://github.com/NII-cloud-operation/sidestickies).
+- Enable the sidestickies extension via the Nbextensions tab.
+*Note: you need to enable both "Sidestickies for file tree" and "Sidestickies for notebook" nbextensions.*
+
+Using ep_weave(Etherpad) https://github.com/NII-cloud-operation/ep_weave :
+- Add `-e SIDESTICKIES_EP_WEAVE_URL=http://ep_weave:9001 -e SIDESTICKIES_EP_WEAVE_API_KEY=YOUR_ETHERPAD_APIKEY` to docker options.
 - Enable the sidestickies extension via the Nbextensions tab.
 *Note: you need to enable both "Sidestickies for file tree" and "Sidestickies for notebook" nbextensions.*
 

--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -27,6 +27,7 @@ if 'SIDESTICKIES_EP_WEAVE_URL' in os.environ:
 
 if 'SIDESTICKIES_EP_WEAVE_API_KEY' in os.environ:
     c.EpWeaveAPI.apikey = os.environ['SIDESTICKIES_EP_WEAVE_API_KEY']
+    del os.environ['SIDESTICKIES_EP_WEAVE_API_KEY']
 
 if 'SIDESTICKIES_EP_WEAVE_API_URL' in os.environ:
     c.EpWeaveAPI.api_url = os.environ['SIDESTICKIES_EP_WEAVE_API_URL']

--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -20,6 +20,17 @@ if 'SIDESTICKIES_SCRAPBOX_COOKIE_CONNECT_SID' in os.environ:
 if 'SIDESTICKIES_SCRAPBOX_PROJECT_ID' in os.environ:
     c.ScrapboxAPI.project_id = os.environ['SIDESTICKIES_SCRAPBOX_PROJECT_ID']
 
+if 'SIDESTICKIES_EP_WEAVE_URL' in os.environ:
+    # Enables EpWeaveAPI
+    c.SidestickiesAPI.api_class = "nbtags.api.EpWeaveAPI"
+    c.EpWeaveAPI.url = os.environ['SIDESTICKIES_EP_WEAVE_URL']
+
+if 'SIDESTICKIES_EP_WEAVE_API_KEY' in os.environ:
+    c.EpWeaveAPI.apikey = os.environ['SIDESTICKIES_EP_WEAVE_API_KEY']
+
+if 'SIDESTICKIES_EP_WEAVE_API_URL' in os.environ:
+    c.EpWeaveAPI.api_url = os.environ['SIDESTICKIES_EP_WEAVE_API_URL']
+
 if 'NBSEARCHDB_SOLR_BASE_URL' in os.environ:
     c.NBSearchDB.solr_base_url = os.environ['NBSEARCHDB_SOLR_BASE_URL']
 


### PR DESCRIPTION
sidestickiesをep_weaveに対応できるよう、設定用環境変数を追加しました。

- `SIDESTICKIES_EP_WEAVE_URL` ... ep_weaveのURL (このオプションを指定すると、sidestickiesのBackend APIとしてep_weaveが選択される)
- `SIDESTICKIES_EP_WEAVE_API_KEY` ... etherpadのAPIKEY
- (任意) `SIDESTICKIES_EP_WEAVE_API_URL` ... sidestickies -> ep_weaveのアクセス用URLを個別に指定すべき場合のURL (Internal IP等)