### PR TITLE
Add owner field for NBSearch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/scipy-notebook:latest
+FROM jupyter/scipy-notebook:lab-3.6.3
 MAINTAINER https://github.com/NII-cloud-operation
 
 USER root
@@ -36,15 +36,15 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
     apt-get -y install sshpass openssl ipmitool libssl-dev libffi-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    conda install --quiet --yes requests paramiko ansible && \
-    conda clean --all -f -y
+    mamba install --quiet --yes requests paramiko ansible && \
+    mamba clean --all -f -y
 
 ### Utilities
 RUN apt-get update && apt-get install -y virtinst dnsutils zip tree jq rsync iputils-ping && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    conda install --quiet --yes papermill && \
+    mamba install --quiet --yes papermill && \
     pip --no-cache-dir install netaddr pyapi-gitlab runipy pysnmp pysnmp-mibs && \
-    conda clean --all -f -y
+    mamba clean --all -f -y
 
 ### Add files
 RUN mkdir -p /etc/ansible && cp /tmp/ansible.cfg /etc/ansible/ansible.cfg

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ You will be able to use NBSearch once you set up your Solr and S3 compatible sto
 - `-e NBSEARCHDB_BASE_DIR=your_notebook_home_dir` - Notebook directory to be searchable(default: `/home/$NB_USER`)
 - `-e NBSEARCHDB_MY_SERVER_URL=your_notebook_server_url` - URL of my server, used to identify the notebooks on this server(default: `http://localhost:8888/`)
 - `-e NBSEARCHDB_AUTO_UPDATE=1` - Launch lsyncd process to update the index of Solr when local files are updated automatically
+- `-e NBSEARCHDB_OWNER=username` - The value of owner field for updating solr index(default: the value of environment variable `JUPYTERHUB_USER` or `NB_USER`)
 - `-e NBSEARCHDB_UPDATE_INDEX_OPT` - Options for the `update-index` NBSearch command invoked by the lsyncd process
 
 ### Using NBWhisper

--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -82,6 +82,14 @@ c.LocalSource.server = os.environ['NBSEARCHDB_MY_SERVER_URL'] \
                        if is_env_var_defined('NBSEARCHDB_MY_SERVER_URL') else \
                        'http://localhost:8888/'
 
+# owner field for updating solr index: NBSEARCHDB_OWNER (primary) -> JUPYTERHUB_USER -> NB_USER
+if is_env_var_defined('NBSEARCHDB_OWNER'):
+    c.LocalSource.owner = os.environ['NBSEARCHDB_OWNER']
+elif is_env_var_defined('JUPYTERHUB_USER'):
+    c.LocalSource.owner = os.environ['JUPYTERHUB_USER']
+elif is_env_var_defined('NB_USER'):
+    c.LocalSource.owner = os.environ['NB_USER']
+
 if is_env_var_defined('NBWHISPER_SKYWAY_API_TOKEN'):
     c.NBWhisper.skyway_api_token = os.environ['NBWHISPER_SKYWAY_API_TOKEN']
     # Secrets removed from environment variables

--- a/conf/jupyter_notebook_config.py
+++ b/conf/jupyter_notebook_config.py
@@ -1,4 +1,8 @@
 import os
+
+def is_env_var_defined(varname):
+    return len(os.environ.get(varname, '')) > 0
+
 c.NotebookApp.ip = '*'
 c.NotebookApp.allow_remote_access = True
 c.MultiKernelManager.kernel_manager_class = 'lc_wrapper.AsyncLCWrapperKernelManager'
@@ -7,84 +11,84 @@ c.FileContentsManager.delete_to_trash = False
 c.NotebookApp.quit_button = False
 c.NotebookApp.kernel_spec_manager_class = 'lc_wrapper.LCWrapperKernelSpecManager'
 
-if 'PASSWORD' in os.environ:
+if is_env_var_defined('PASSWORD'):
     from notebook.auth import passwd
     c.NotebookApp.password = passwd(os.environ['PASSWORD'])
     del os.environ['PASSWORD']
 
-if 'SIDESTICKIES_SCRAPBOX_COOKIE_CONNECT_SID' in os.environ:
+if is_env_var_defined('SIDESTICKIES_SCRAPBOX_COOKIE_CONNECT_SID'):
     c.ScrapboxAPI.cookie_connect_sid = os.environ['SIDESTICKIES_SCRAPBOX_'
                                                   'COOKIE_CONNECT_SID']
     del os.environ['SIDESTICKIES_SCRAPBOX_COOKIE_CONNECT_SID']
 
-if 'SIDESTICKIES_SCRAPBOX_PROJECT_ID' in os.environ:
+if is_env_var_defined('SIDESTICKIES_SCRAPBOX_PROJECT_ID'):
     c.ScrapboxAPI.project_id = os.environ['SIDESTICKIES_SCRAPBOX_PROJECT_ID']
 
-if 'SIDESTICKIES_EP_WEAVE_URL' in os.environ:
+if is_env_var_defined('SIDESTICKIES_EP_WEAVE_URL'):
     # Enables EpWeaveAPI
     c.SidestickiesAPI.api_class = "nbtags.api.EpWeaveAPI"
     c.EpWeaveAPI.url = os.environ['SIDESTICKIES_EP_WEAVE_URL']
 
-if 'SIDESTICKIES_EP_WEAVE_API_KEY' in os.environ:
+if is_env_var_defined('SIDESTICKIES_EP_WEAVE_API_KEY'):
     c.EpWeaveAPI.apikey = os.environ['SIDESTICKIES_EP_WEAVE_API_KEY']
     del os.environ['SIDESTICKIES_EP_WEAVE_API_KEY']
 
-if 'SIDESTICKIES_EP_WEAVE_API_URL' in os.environ:
+if is_env_var_defined('SIDESTICKIES_EP_WEAVE_API_URL'):
     c.EpWeaveAPI.api_url = os.environ['SIDESTICKIES_EP_WEAVE_API_URL']
 
-if 'NBSEARCHDB_SOLR_BASE_URL' in os.environ:
+if is_env_var_defined('NBSEARCHDB_SOLR_BASE_URL'):
     c.NBSearchDB.solr_base_url = os.environ['NBSEARCHDB_SOLR_BASE_URL']
 
-if 'NBSEARCHDB_S3_ENDPOINT_URL' in os.environ:
+if is_env_var_defined('NBSEARCHDB_S3_ENDPOINT_URL'):
     c.NBSearchDB.s3_endpoint_url = os.environ['NBSEARCHDB_S3_ENDPOINT_URL']
 
-if 'NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME' in os.environ:
+if is_env_var_defined('NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME'):
     c.NBSearchDB.solr_basic_auth_username = os.environ['NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME']
     del os.environ['NBSEARCHDB_SOLR_BASIC_AUTH_USERNAME']
 
-if 'NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD' in os.environ:
+if is_env_var_defined('NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD'):
     c.NBSearchDB.solr_basic_auth_password = os.environ['NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD']
     del os.environ['NBSEARCHDB_SOLR_BASIC_AUTH_PASSWORD']
 
-if 'NBSEARCHDB_SOLR_NOTEBOOK' in os.environ:
+if is_env_var_defined('NBSEARCHDB_SOLR_NOTEBOOK'):
     c.NBSearchDB.solr_notebook = os.environ['NBSEARCHDB_SOLR_NOTEBOOK']
     del os.environ['NBSEARCHDB_SOLR_NOTEBOOK']
 
-if 'NBSEARCHDB_SOLR_CELL' in os.environ:
+if is_env_var_defined('NBSEARCHDB_SOLR_CELL'):
     c.NBSearchDB.solr_cell = os.environ['NBSEARCHDB_SOLR_CELL']
     del os.environ['NBSEARCHDB_SOLR_CELL']
 
-if 'NBSEARCHDB_S3_ACCESS_KEY' in os.environ:
+if is_env_var_defined('NBSEARCHDB_S3_ACCESS_KEY'):
     c.NBSearchDB.s3_access_key = os.environ['NBSEARCHDB_S3_ACCESS_KEY']
     del os.environ['NBSEARCHDB_S3_ACCESS_KEY']
 
-if 'NBSEARCHDB_S3_SECRET_KEY' in os.environ:
+if is_env_var_defined('NBSEARCHDB_S3_SECRET_KEY'):
     c.NBSearchDB.s3_secret_key = os.environ['NBSEARCHDB_S3_SECRET_KEY']
     del os.environ['NBSEARCHDB_S3_SECRET_KEY']
 
-if 'NBSEARCHDB_S3_REGION_NAME' in os.environ:
+if is_env_var_defined('NBSEARCHDB_S3_REGION_NAME'):
     c.NBSearchDB.s3_region_name = os.environ['NBSEARCHDB_S3_REGION_NAME']
     del os.environ['NBSEARCHDB_S3_REGION_NAME']
 
-if 'NBSEARCHDB_S3_BUCKET_NAME' in os.environ:
+if is_env_var_defined('NBSEARCHDB_S3_BUCKET_NAME'):
     c.NBSearchDB.s3_bucket_name = os.environ['NBSEARCHDB_S3_BUCKET_NAME']
     del os.environ['NBSEARCHDB_S3_BUCKET_NAME']
 
 c.LocalSource.base_dir = os.environ['NBSEARCHDB_BASE_DIR'] \
-                         if 'NBSEARCHDB_BASE_DIR' in os.environ else \
+                         if is_env_var_defined('NBSEARCHDB_BASE_DIR') else \
                          '/home/{}'.format(os.environ['NB_USER'])
 
 c.LocalSource.server = os.environ['NBSEARCHDB_MY_SERVER_URL'] \
-                       if 'NBSEARCHDB_MY_SERVER_URL' in os.environ else \
+                       if is_env_var_defined('NBSEARCHDB_MY_SERVER_URL') else \
                        'http://localhost:8888/'
 
-if 'NBWHISPER_SKYWAY_API_TOKEN' in os.environ:
+if is_env_var_defined('NBWHISPER_SKYWAY_API_TOKEN'):
     c.NBWhisper.skyway_api_token = os.environ['NBWHISPER_SKYWAY_API_TOKEN']
     # Secrets removed from environment variables
     del os.environ['NBWHISPER_SKYWAY_API_TOKEN']
 
-if 'NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM' in os.environ:
+if is_env_var_defined('NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM'):
     c.NBWhisper.room_mode_for_waiting_room = os.environ['NBWHISPER_ROOM_MODE_FOR_WAITING_ROOM']
 
-if 'NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM' in os.environ:
+if is_env_var_defined('NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM'):
     c.NBWhisper.room_mode_for_talking_room = os.environ['NBWHISPER_ROOM_MODE_FOR_TALKING_ROOM']

--- a/conf/nbsearch/launch.sh
+++ b/conf/nbsearch/launch.sh
@@ -3,7 +3,7 @@
 set -xe
 
 # Launch auto updater
-if [[ ! -z "${NBSEARCHDB_AUTO_UPDATE}" ]] ; then
+if [[ "${NBSEARCHDB_AUTO_UPDATE:-}" -eq 1 ]] ; then
   if [ $(id -u) == 0 ] ; then
     sudo -E -u $NB_USER lsyncd /opt/nbsearch/update-index.lua
   else


### PR DESCRIPTION
Add owner field for NBSearch and fix related problems.

- Fixed Dockerfile to pin the base image (Since it is not yet compatible with lab v4.)
- Fixed the configuration script to ignore environment variables with empty string (related to https://github.com/NII-cloud-operation/OperationHub/pull/30 )
- Add owner field for NBSearch ... using: NBSEARCHDB_OWNER (primary) -> JUPYTERHUB_USER -> NB_USER