### PR TITLE
Add icon for kernelspec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,11 +127,6 @@ RUN jupyter labextension install ${nblineage_release_url}${nblineage_release_tag
     # jupyter nbclassic-extension enable contrib_nbextensions_help_item/main --sys-prefix && \
     jupyter nbclassic-extension enable collapsible_headings/main --sys-prefix && \
     jupyter nbclassic-extension enable toc2/main --sys-prefix && \
-    python -m bash_kernel.install --sys-prefix && \
-    jupyter kernelspec install /tmp/kernels/python3-wrapper --sys-prefix && \
-    jupyter kernelspec install /tmp/kernels/bash-wrapper --sys-prefix && \
-    jupyter wrapper-kernelspec install /tmp/wrapper-kernels/python3 --sys-prefix && \
-    jupyter wrapper-kernelspec install /tmp/wrapper-kernels/bash --sys-prefix && \
     # jlpm cache clean && \
     # npm cache clean --force && \
     fix-permissions /home/$NB_USER
@@ -140,6 +135,15 @@ RUN jupyter labextension install ${nblineage_release_url}${nblineage_release_tag
     # jupyter labextension enable nbtags
     # jupyter labextension enable nbsearch
 
+### kernels
+RUN chmod +x /tmp/wrapper-kernels/prepare-icons.sh && \
+    /tmp/wrapper-kernels/prepare-icons.sh && \
+    python -m bash_kernel.install --sys-prefix && \
+    jupyter kernelspec install /tmp/kernels/python3-wrapper --sys-prefix && \
+    jupyter kernelspec install /tmp/kernels/bash-wrapper --sys-prefix && \
+    jupyter wrapper-kernelspec install /tmp/wrapper-kernels/python3 --sys-prefix && \
+    jupyter wrapper-kernelspec install /tmp/wrapper-kernels/bash --sys-prefix && \
+    fix-permissions /home/$NB_USER
 
 ### nbconfig
 RUN mkdir -p $CONDA_DIR/etc/jupyter/nbconfig/notebook.d && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,6 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Copy config files
-ADD conf /tmp/
-RUN mkdir -p $CONDA_DIR/etc/jupyter && \
-    cp -f /tmp/jupyter_notebook_config.py \
-       $CONDA_DIR/etc/jupyter/jupyter_notebook_config.py
-
 SHELL ["/bin/bash", "-c"]
 
 ### ansible
@@ -46,9 +40,6 @@ RUN apt-get update && apt-get install -y virtinst dnsutils zip tree jq rsync ipu
     conda install --quiet --yes papermill && \
     pip --no-cache-dir install netaddr pyapi-gitlab runipy pysnmp pysnmp-mibs && \
     conda clean --all -f -y
-
-### Add files
-RUN mkdir -p /etc/ansible && cp /tmp/ansible.cfg /etc/ansible/ansible.cfg
 
 #### Visualization
 RUN pip --no-cache-dir install folium
@@ -134,6 +125,13 @@ RUN jupyter labextension install ${nblineage_release_url}${nblineage_release_tag
     # To enable the nbsearch or sidestickies, you need to run the following command in the notebook.
     # jupyter labextension enable nbtags
     # jupyter labextension enable nbsearch
+
+# Copy config files
+ADD conf /tmp/
+RUN mkdir -p $CONDA_DIR/etc/jupyter && \
+    cp -f /tmp/jupyter_notebook_config.py \
+       $CONDA_DIR/etc/jupyter/jupyter_notebook_config.py && \
+    mkdir -p /etc/ansible && cp /tmp/ansible.cfg /etc/ansible/ansible.cfg
 
 ### kernels
 RUN chmod +x /tmp/wrapper-kernels/prepare-icons.sh && \

--- a/conf/wrapper-kernels/prepare-icons.sh
+++ b/conf/wrapper-kernels/prepare-icons.sh
@@ -16,7 +16,7 @@ KERNEL_PATH=${BASE_PATH}/python3
 SOURCE_PATH=/opt/conda/share/jupyter/kernels/python3
 cp ${SOURCE_PATH}/logo-32x32.png ${KERNEL_PATH}/logo-32x32.png
 cp ${SOURCE_PATH}/logo-64x64.png ${KERNEL_PATH}/logo-64x64.png
-cp ${SOURCE_PATH}/logo.svg ${KERNEL_PATH}/logo-svg.svg
+cp ${SOURCE_PATH}/logo-svg.svg ${KERNEL_PATH}/logo-svg.svg
 
 # For Bash, copy the icons from https://github.com/odb/official-bash-logo/
 # ex.) https://github.com/odb/official-bash-logo/blob/master/assets/Logos/Icons/PNG/16x16.png

--- a/conf/wrapper-kernels/prepare-icons.sh
+++ b/conf/wrapper-kernels/prepare-icons.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -xe
+
+# Download the icons for wrapper-kernels
+# The widget of kernels in the JupyterLab will be broken if the icons does not exist
+# - logo-32x32.png
+# - logo-64x64.png
+# - logo-svg.svg
+
+# the path of scripts
+BASE_PATH=$(dirname $0)
+
+# For Python3, copy the icons from /opt/conda/share/jupyter/kernels/python3/
+KERNEL_PATH=${BASE_PATH}/python3
+SOURCE_PATH=/opt/conda/share/jupyter/kernels/python3
+cp ${SOURCE_PATH}/logo-32x32.png ${KERNEL_PATH}/logo-32x32.png
+cp ${SOURCE_PATH}/logo-64x64.png ${KERNEL_PATH}/logo-64x64.png
+cp ${SOURCE_PATH}/logo.svg ${KERNEL_PATH}/logo-svg.svg
+
+# For Bash, copy the icons from https://github.com/odb/official-bash-logo/
+# ex.) https://github.com/odb/official-bash-logo/blob/master/assets/Logos/Icons/PNG/16x16.png
+KERNEL_PATH=${BASE_PATH}/bash
+
+SOURCE_BASE_URL=https://raw.githubusercontent.com/odb/official-bash-logo/master/assets/Logos/Icons
+curl -L ${SOURCE_BASE_URL}/PNG/16x16.png -o ${KERNEL_PATH}/logo-32x32.png
+curl -L ${SOURCE_BASE_URL}/PNG/32x32.png -o ${KERNEL_PATH}/logo-64x64.png
+curl -L ${SOURCE_BASE_URL}/SVG/16x16.svg -o ${KERNEL_PATH}/logo-svg.svg


### PR DESCRIPTION
Added icons because the kernels tab in JupyterLab is broken if kernelspec does not have icons.
In addition, the order of command execution has been modified to utilize the build cache.