### PR TITLE
Modify the version of the base image for the extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:notebook-7.2.0
+FROM quay.io/jupyter/scipy-notebook:notebook-7.1.3
 MAINTAINER https://github.com/NII-cloud-operation
 
 USER root


### PR DESCRIPTION
Downgraded the base version to 7.1.3 because some extensions do not work as expected in Jupyter Notebook 7.2.0.