### PR TITLE
Upgrade base image and extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:notebook-7.4.3
+FROM quay.io/jupyter/scipy-notebook:notebook-7.4.7
 MAINTAINER https://github.com/NII-cloud-operation
 
 USER root
@@ -66,7 +66,7 @@ RUN pip --no-cache-dir install folium
 #### sidestickies (NII) - https://github.com/NII-cloud-operation/sidestickies
 #### nbsearch (NII) - https://github.com/NII-cloud-operation/nbsearch
 #### nbwhisper (NII) - https://github.com/NII-cloud-operation/nbwhisper
-ENV nblineage_release_tag=0.2.0.rc1 \
+ENV nblineage_release_tag=0.2.0.rc2 \
     nblineage_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/releases/download/ \
     lc_index_release_tag=0.2.0.rc4 \
     lc_index_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_index/releases/download/ \
@@ -78,9 +78,9 @@ ENV nblineage_release_tag=0.2.0.rc1 \
     lc_wrapper_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/releases/download/ \
     diff_release_tag=0.2.0.rc2 \
     diff_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_notebook_diff/releases/download/ \
-    sidestickies_release_tag=0.3.1.rc3 \
+    sidestickies_release_tag=0.3.1.rc4 \
     sidestickies_release_url=https://github.com/NII-cloud-operation/sidestickies/releases/download/ \
-    nbsearch_release_tag=0.2.0.rc3 \
+    nbsearch_release_tag=0.2.0.rc5 \
     nbsearch_release_url=https://github.com/NII-cloud-operation/nbsearch/releases/download/ \
     nbwhisper_release_tag=0.2.0.rc1 \
     nbwhisper_release_url=https://github.com/NII-cloud-operation/nbwhisper/releases/download/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,8 @@ ENV nblineage_release_tag=0.2.0.rc1 \
     lc_multi_outputs_release_url=https://github.com/NII-cloud-operation/Jupyter-multi_outputs/releases/download/ \
     lc_run_through_release_tag=0.2.0.rc7 \
     lc_run_through_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_run_through/releases/download/ \
+    lc_wrapper_release_tag=1.3.2.rc0 \
+    lc_wrapper_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/releases/download/ \
     diff_release_tag=0.2.0.rc2 \
     diff_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_notebook_diff/releases/download/ \
     sidestickies_release_tag=0.3.1.rc3 \
@@ -89,7 +91,7 @@ RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
     jupyterlab-language-pack-ja-JP \
     ${nblineage_release_url}${nblineage_release_tag}/nblineage-${nblineage_release_tag}.tar.gz \
     ${lc_run_through_release_url}${lc_run_through_release_tag}/lc_run_through-${lc_run_through_release_tag}.tar.gz \
-    https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master \
+    ${lc_wrapper_release_url}${lc_wrapper_release_tag}/lc_wrapper-${lc_wrapper_release_tag}.tar.gz \
     ${lc_multi_outputs_release_url}${lc_multi_outputs_release_tag}/lc_multi_outputs-${lc_multi_outputs_release_tag}.tar.gz \
     ${lc_index_release_url}${lc_index_release_tag}/lc_index-${lc_index_release_tag}.tar.gz \
     ${diff_release_url}${diff_release_tag}/lc_notebook_diff-${diff_release_tag}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ RUN pip --no-cache-dir install folium
 #### sidestickies (NII) - https://github.com/NII-cloud-operation/sidestickies
 #### nbsearch (NII) - https://github.com/NII-cloud-operation/nbsearch
 #### nbwhisper (NII) - https://github.com/NII-cloud-operation/nbwhisper
-ENV nblineage_release_tag=0.2.0.rc2 \
+ENV nblineage_release_tag=0.2.0.rc3 \
     nblineage_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/releases/download/ \
-    lc_index_release_tag=0.2.0.rc4 \
+    lc_index_release_tag=0.2.0.rc6 \
     lc_index_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_index/releases/download/ \
     lc_multi_outputs_release_tag=2.2.0.rc3 \
     lc_multi_outputs_release_url=https://github.com/NII-cloud-operation/Jupyter-multi_outputs/releases/download/ \


### PR DESCRIPTION
## Summary
- Upgrade base image from notebook-7.4.3 to notebook-7.4.7
- Use LC_wrapper release 1.3.2.rc0
- Update extension versions:
  - nblineage: 0.2.0.rc1 → 0.2.0.rc2
  - sidestickies: 0.3.1.rc3 → 0.3.1.rc4
  - nbsearch: 0.2.0.rc3 → 0.2.0.rc5