### PR TITLE
Upgrade base image to notebook-7.5.0 and update extensions

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -1,0 +1,30 @@
+# Reference https://mybinder.readthedocs.io/en/latest/howto/gh-actions-badges.html
+name: Binder Badge
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+
+jobs:
+  binder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: comment on PR with Binder link
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var PR_HEAD_USERREPO = process.env.PR_HEAD_USERREPO;
+            var PR_HEAD_REF = process.env.PR_HEAD_REF;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${PR_HEAD_USERREPO}/${PR_HEAD_REF}?urlpath=tree) :point_left: Launch a Binder on branch _${PR_HEAD_USERREPO}/${PR_HEAD_REF}_`
+            })
+        env:
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_USERREPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,13 +83,15 @@ ENV nblineage_release_tag=0.2.0.rc3 \
     nbwhisper_release_tag=0.2.0.rc2 \
     nbwhisper_release_url=https://github.com/NII-cloud-operation/nbwhisper/releases/download/ \
     lc_toc_button_release_tag=0.1.0.rc2 \
-    lc_toc_button_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_ToC_button/releases/download/
+    lc_toc_button_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_ToC_button/releases/download/ \
+    lc_wrapper_release_tag=1.3.2.rc0 \
+    lc_wrapper_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/releases/download/
 RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
     pip --no-cache-dir install six bash_kernel \
     jupyterlab-language-pack-ja-JP \
     ${nblineage_release_url}${nblineage_release_tag}/nblineage-${nblineage_release_tag}.tar.gz \
     ${lc_run_through_release_url}${lc_run_through_release_tag}/lc_run_through-${lc_run_through_release_tag}.tar.gz \
-    https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/tarball/master \
+    ${lc_wrapper_release_url}${lc_wrapper_release_tag}/lc_wrapper-${lc_wrapper_release_tag}.tar.gz \
     ${lc_multi_outputs_release_url}${lc_multi_outputs_release_tag}/lc_multi_outputs-${lc_multi_outputs_release_tag}.tar.gz \
     ${lc_index_release_url}${lc_index_release_tag}/lc_index-${lc_index_release_tag}.tar.gz \
     ${diff_release_url}${diff_release_tag}/lc_notebook_diff-${diff_release_tag}.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:notebook-7.4.3
+FROM quay.io/jupyter/scipy-notebook:notebook-7.5.0
 MAINTAINER https://github.com/NII-cloud-operation
 
 USER root
@@ -66,9 +66,9 @@ RUN pip --no-cache-dir install folium
 #### sidestickies (NII) - https://github.com/NII-cloud-operation/sidestickies
 #### nbsearch (NII) - https://github.com/NII-cloud-operation/nbsearch
 #### nbwhisper (NII) - https://github.com/NII-cloud-operation/nbwhisper
-ENV nblineage_release_tag=0.2.0.rc1 \
+ENV nblineage_release_tag=0.2.0.rc3 \
     nblineage_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_nblineage/releases/download/ \
-    lc_index_release_tag=0.2.0.rc4 \
+    lc_index_release_tag=0.2.0.rc6 \
     lc_index_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_index/releases/download/ \
     lc_multi_outputs_release_tag=2.2.0.rc3 \
     lc_multi_outputs_release_url=https://github.com/NII-cloud-operation/Jupyter-multi_outputs/releases/download/ \
@@ -76,11 +76,11 @@ ENV nblineage_release_tag=0.2.0.rc1 \
     lc_run_through_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_run_through/releases/download/ \
     diff_release_tag=0.2.0.rc2 \
     diff_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_notebook_diff/releases/download/ \
-    sidestickies_release_tag=0.3.1.rc3 \
+    sidestickies_release_tag=0.3.1.rc5 \
     sidestickies_release_url=https://github.com/NII-cloud-operation/sidestickies/releases/download/ \
-    nbsearch_release_tag=0.2.0.rc3 \
+    nbsearch_release_tag=0.2.0.rc5 \
     nbsearch_release_url=https://github.com/NII-cloud-operation/nbsearch/releases/download/ \
-    nbwhisper_release_tag=0.2.0.rc1 \
+    nbwhisper_release_tag=0.2.0.rc2 \
     nbwhisper_release_url=https://github.com/NII-cloud-operation/nbwhisper/releases/download/ \
     lc_toc_button_release_tag=0.1.0.rc2 \
     lc_toc_button_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_ToC_button/releases/download/
@@ -168,8 +168,9 @@ RUN CUSTOM_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; prin
     mkdir -p $CUSTOM_DIR/codemirror/addon/merge/ && \
     curl -fL https://raw.githubusercontent.com/cytoscape/cytoscape.js/master/dist/cytoscape.min.js > $CUSTOM_DIR/cytoscape.min.js && \
     curl -fL https://raw.githubusercontent.com/iVis-at-Bilkent/cytoscape.js-view-utilities/master/cytoscape-view-utilities.js > $CUSTOM_DIR/cytoscape-view-utilities.js && \
-    curl -fL https://raw.githubusercontent.com/NII-cloud-operation/Jupyter-LC_notebook_diff/master/html/jupyter-notebook-diff.js > $CUSTOM_DIR/jupyter-notebook-diff.js && \
-    curl -fL https://raw.githubusercontent.com/NII-cloud-operation/Jupyter-LC_notebook_diff/master/html/jupyter-notebook-diff.css > $CUSTOM_DIR/jupyter-notebook-diff.css && \
+    curl -fL ${diff_release_url}${diff_release_tag}/lc_notebook_diff-${diff_release_tag}.tar.gz | tar xzf - -C /tmp && \
+    cp /tmp/lc_notebook_diff-*/lc_notebook_diff/nbextension/jupyter-notebook-diff.js $CUSTOM_DIR/ && \
+    cp /tmp/lc_notebook_diff-*/lc_notebook_diff/nbextension/jupyter-notebook-diff.css $CUSTOM_DIR/ && \
     curl -fL https://cdnjs.cloudflare.com/ajax/libs/diff_match_patch/20121119/diff_match_patch.js > $CUSTOM_DIR/diff_match_patch.js && \
     curl -fL https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.35.0/addon/merge/merge.js > $CUSTOM_DIR/codemirror/addon/merge/merge.js && \
     curl -fL https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.35.0/addon/merge/merge.min.css > $CUSTOM_DIR/merge.min.css


### PR DESCRIPTION
- Upgrade base image from `notebook-7.4.3` to `notebook-7.5.0`
- Update extensions to latest releases:
  - nblineage: 0.2.0.rc1 → 0.2.0.rc3
  - lc_index: 0.2.0.rc4 → 0.2.0.rc6
  - sidestickies: 0.3.1.rc3 → 0.3.1.rc5
  - nbsearch: 0.2.0.rc3 → 0.2.0.rc5
  - nbwhisper: 0.2.0.rc1 → 0.2.0.rc2
  - lc_wrapper: master → 1.3.2.rc0 (release tarball)
- Fix #135: Replace broken raw.githubusercontent.com URLs with release tarball for notebook_diff js/css files
- Add binder-on-pr workflow