### PR TITLE
Pin ansible version to <10 for Python <3.7 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
     apt-get -y install sshpass openssl ipmitool libssl-dev libffi-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    conda install --quiet --yes requests paramiko ansible asciinema && \
+    conda install --quiet --yes requests paramiko "ansible<10" asciinema && \
     conda clean --all -f -y
 
 ### Utilities


### PR DESCRIPTION
Pin ansible version to <10 to support target servers with Python <3.7 environments.