### PR TITLE
Add GitHub Actions workflow for multiarch Docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,62 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+      - sc-demo
+      - 'feature/**'
+    tags:
+      - '*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure Docker to use /mnt
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p /mnt/docker
+          sudo tee /etc/docker/daemon.json <<EOF
+          {
+            "data-root": "/mnt/docker"
+          }
+          EOF
+          sudo systemctl start docker
+          docker info | grep "Docker Root Dir"
+          df -h
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKER_IMAGE || 'niicloudoperation/notebook' }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# base-demo-lab 2024-11-17
-FROM niicloudoperation/notebook@sha256:9857671dd9894da168da75fd5d66ccd362fc333772bf9e88c3136c5164f016fb
+# base-demo-lab 2025-12-02
+FROM niicloudoperation/notebook@sha256:472cc2cac9172551321253e79d32a4245b36592a26aa270f2c21fa99b3c6f57a
 
 USER root
 


### PR DESCRIPTION
- Add GitHub Actions workflow to build and push Docker images
- Support multi-architecture builds (linux/amd64, linux/arm64)
- Trigger on main branch, sc-demo branch, feature/* branches, and tags
- Update base image