### PR TITLE
Remove jupyter-ai to fix freeze icon conflict

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,8 +104,7 @@ RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
     ${nbsearch_release_url}${nbsearch_release_tag}/nbsearch-${nbsearch_release_tag}.tar.gz \
     ${nbwhisper_release_url}${nbwhisper_release_tag}/nbwhisper-${nbwhisper_release_tag}.tar.gz \
     ${lc_toc_button_release_url}${lc_toc_button_release_tag}/table_of_contents-${lc_toc_button_release_tag}.tar.gz \
-    ${mynerva_release_url}${mynerva_release_tag}/jupyter_mynerva-${mynerva_release_tag}.tar.gz \
-    jupyter-ai langchain-anthropic langchain-openai langchain-google-genai
+    ${mynerva_release_url}${mynerva_release_tag}/jupyter_mynerva-${mynerva_release_tag}.tar.gz
 
 RUN jupyter nblineage quick-setup --sys-prefix && \
     jupyter nbclassic-extension install --py lc_run_through --sys-prefix && \


### PR DESCRIPTION
## Summary
- Remove `jupyter-ai` and its LLM dependencies from the Docker image
- `@jupyter-ai-contrib/server-documents` (a dependency of `jupyter-ai`) monkey-patches `CodeCell._updatePrompt` ( https://github.com/jupyter-ai-contrib/jupyter-server-documents/blob/main/src/notebook-factory/notebook-factory.ts#L189-L205 ), which calls `_setPrompt` and triggers `InputPrompt.executionCount` setter ( https://github.com/jupyterlab/jupyterlab/blob/v4.5.6/packages/cells/src/inputarea.ts#L282-L289 ) to overwrite `textContent` of the prompt node, destroying the `FrozenWidget` attached by `lc_run_through`