### PR TITLE
Re-enable nbsearch / nbtags server extensions and restore logo customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ ENV nblineage_release_tag=0.2.0.rc5 \
     lc_run_through_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_run_through/releases/download/ \
     diff_release_tag=0.2.0.rc3 \
     diff_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_notebook_diff/releases/download/ \
-    sidestickies_release_tag=0.3.1.rc5 \
+    sidestickies_release_tag=0.3.1.rc6 \
     sidestickies_release_url=https://github.com/NII-cloud-operation/sidestickies/releases/download/ \
-    nbsearch_release_tag=0.2.0.rc6 \
+    nbsearch_release_tag=0.2.0.rc7 \
     nbsearch_release_url=https://github.com/NII-cloud-operation/nbsearch/releases/download/ \
     nbwhisper_release_tag=0.2.0.rc4 \
     nbwhisper_release_url=https://github.com/NII-cloud-operation/nbwhisper/releases/download/ \
@@ -80,8 +80,7 @@ ENV nblineage_release_tag=0.2.0.rc5 \
     mynerva_release_url=https://github.com/NII-cloud-operation/jupyter-mynerva/releases/download/ \
     nblibram_release_tag=v2026.4.2 \
     nblibram_release_url=https://github.com/NII-cloud-operation/nblibram/releases/download/
-RUN pip --no-cache-dir install jupyter_nbextensions_configurator && \
-    pip --no-cache-dir install six bash_kernel \
+RUN pip --no-cache-dir install six bash_kernel \
     jupyterlab-language-pack-ja-JP \
     ${nblineage_release_url}${nblineage_release_tag}/nblineage-${nblineage_release_tag}.tar.gz \
     ${lc_run_through_release_url}${lc_run_through_release_tag}/lc_run_through-${lc_run_through_release_tag}.tar.gz \
@@ -141,10 +140,11 @@ RUN fix-permissions /home/$NB_USER
 RUN cp /tmp/bash_env /etc/bash_env
 
 #### CSS for JupyterLab
-RUN CUSTOM_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')/notebook/custom && \
+RUN LOGO_DATA_URI="data:image/png;base64,$(base64 -w0 /tmp/logo.png)" && \
+    sed -i "s|__LOGO_DATA_URI__|${LOGO_DATA_URI}|" /tmp/nb7-custom.css /tmp/lab-custom.css && \
+    CUSTOM_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')/notebook/custom && \
     mkdir -p $CUSTOM_DIR && \
     cp /tmp/nb7-custom.css $CUSTOM_DIR/custom.css && \
-    cp /tmp/logo.png $CUSTOM_DIR/logo.png && \
     CUSTOM_DIR=$(python -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())')/jupyterlab/themes/@jupyterlab && \
     cat /tmp/lab-custom.css >> $CUSTOM_DIR/theme-dark-extension/index.css && \
     cat /tmp/lab-custom.css >> $CUSTOM_DIR/theme-light-extension/index.css && \

--- a/conf/lab-custom.css
+++ b/conf/lab-custom.css
@@ -11,7 +11,7 @@
     left: 0;
     width: 26px;
     height: 26px;
-    background-image: url(../../../../../custom/logo.png);
+    background-image: url('__LOGO_DATA_URI__');
     background-size: cover;
     background-position: left;
     pointer-events: none;

--- a/conf/nb7-custom.css
+++ b/conf/nb7-custom.css
@@ -16,7 +16,7 @@
     left: 0;
     width: 182px;
     height: 34px;
-    background-image: url('./logo.png');
+    background-image: url('__LOGO_DATA_URI__');
     background-size: cover;
     background-position: center;
     pointer-events: none;


### PR DESCRIPTION
## Summary
- Bump `nbsearch` to `0.2.0.rc7` and `sidestickies` to `0.3.1.rc6`. Both releases now ship `etc/jupyter/jupyter_server_config.d/<name>.json`, so the server extensions are auto-enabled at install time. After #154 dropped the `nbclassic-serverextension enable` block, these extensions had no replacement registration path and stopped loading; the new releases restore that.
- Drop `pip install jupyter_nbextensions_configurator`. With nbclassic gone it has no host UI to configure.
- Embed `logo.png` as a `data:` URI in `nb7-custom.css` and `lab-custom.css` via a build-time `sed` substitution. Notebook 7's only `/custom/` handler serves `custom.css` exclusively; the previous `/custom/logo.png` URL relied on nbclassic's static handler and 404s after #154 removed nbclassic. Source CSS uses an explicit `__LOGO_DATA_URI__` placeholder so the substitution intent is visible.