### PR TITLE
Upgrade jupyter-mynerva to 0.1.3.rc5 and bump base image to notebook-7.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/jupyter/scipy-notebook:notebook-7.5.5
+FROM quay.io/jupyter/scipy-notebook:notebook-7.5.7
 MAINTAINER https://github.com/NII-cloud-operation
 
 USER root
@@ -76,7 +76,7 @@ ENV nblineage_release_tag=0.2.0.rc5 \
     lc_toc_button_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_ToC_button/releases/download/ \
     lc_wrapper_release_tag=1.3.2.rc2 \
     lc_wrapper_release_url=https://github.com/NII-cloud-operation/Jupyter-LC_wrapper/releases/download/ \
-    mynerva_release_tag=0.1.3.rc3 \
+    mynerva_release_tag=0.1.3.rc5 \
     mynerva_release_url=https://github.com/NII-cloud-operation/jupyter-mynerva/releases/download/ \
     nblibram_release_tag=v2026.4.2 \
     nblibram_release_url=https://github.com/NII-cloud-operation/nblibram/releases/download/


### PR DESCRIPTION
## Summary
- Upgrade jupyter-mynerva: `0.1.3.rc3` → `0.1.3.rc5`
  - rc4: fetch chat model list dynamically from provider APIs, add Bedrock Converse API support, fix user-config model refresh
  - rc5: add nbsearch notebook search actions, replace the custom JSON tool protocol with native LLM tool calling
- Bump base image: `quay.io/jupyter/scipy-notebook:notebook-7.5.5` → `notebook-7.5.7`

## Verification
- Local `docker build` succeeds.
- Container run: server extensions (nbsearch / nbtags / nblineage / nbwhisper / nbdime) load, and JupyterLab serves with `@jupyter-notebook/lab-extension v7.5.7`.