### PR TITLE
Upgrade the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# base-demo-lab 2026-04-25
-FROM niicloudoperation/notebook@sha256:ae28bd58aa707bb11e17d9cd8c1f8f38b981dfc794f6c7661769ae7ffe5fcbf0
+# base-demo-lab 2026-06-10
+FROM niicloudoperation/notebook@sha256:c421349cd1efbe476fa8b841c7d1c2c36c28bb6b29b7a93b25e0e464a8472c7b
 
 USER root
 
@@ -8,12 +8,6 @@ RUN chown jovyan:users -R /home/$NB_USER/
 
 ADD sample-pads /pads.d
 RUN chown jovyan:users -R /pads.d
-
-# Workaround: replace jupyter-mynerva with 0.1.3.stream2 (lazy SDK imports)
-# to avoid JupyterHub spawn 30s timeout caused by slow extension load.
-RUN pip uninstall -y jupyter_mynerva && \
-    pip install --no-cache-dir https://github.com/NII-cloud-operation/jupyter-mynerva/releases/download/0.1.3.stream2/jupyter_mynerva-0.1.3.stream2.tar.gz && \
-    jupyter labextension enable jupyter-mynerva --level=system
 
 USER $NB_USER
 


### PR DESCRIPTION
- Update base image to base-demo-lab 2026-06-10 (jupyter-mynerva 0.1.3.rc5 / notebook 7.5.7)
- Remove the jupyter-mynerva 0.1.3.stream2 override (reverts #149); the image now uses 0.1.3.rc5 from the base